### PR TITLE
TAO-8629 - The class TestRunnerService is refactored

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return array(
     'label' => 'Linear Test Model',
     'description' => 'A simple linear test model',
     'license' => 'GPL-2.0',
-    'version' => '3.2.1',
+    'version' => '3.2.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=12.21.4',

--- a/model/TestRunnerService.php
+++ b/model/TestRunnerService.php
@@ -22,7 +22,7 @@
 namespace oat\taoTestLinear\model;
 
 
-use core_kernel_classes_Class;
+use oat\tao\model\OntologyClassService;
 
 /**
  * TestRunner service to get data of the test
@@ -31,7 +31,7 @@ use core_kernel_classes_Class;
  * @author Antoine Robin, <antoine.robin@vesperiagroup.com>
  * @package taoTestLinear
  */
-class TestRunnerService extends \tao_models_classes_ClassService{
+class TestRunnerService extends OntologyClassService {
 
     //volatile
     private $itemDataCache = null;
@@ -83,6 +83,6 @@ class TestRunnerService extends \tao_models_classes_ClassService{
      */
     public function getRootClass()
     {
-        return new core_kernel_classes_Class(CLASS_SIMPLE_DELIVERYCONTENT);
+        return $this->getClass(CLASS_SIMPLE_DELIVERYCONTENT);
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -57,6 +57,6 @@ class Updater extends \common_ext_ExtensionUpdater
 		    $this->setVersion('1.0.0');
 		}
 
-		$this->skip('1.0.0', '3.2.1');
+		$this->skip('1.0.0', '3.2.2');
 	}
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8629

All classes extend the class tao_models_classes_ClassService are unit testable and now extend OntologyClassService class

__construct() methods of the classes are empty

All classes directly or indirectly extending tao_models_classes_ClassService do not have a custom constructor

The behaviour of the modified classes remains unchanged
The TAO platform still continue to behave as it was